### PR TITLE
Update to Spring Boot 1.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.2.RELEASE</version>
+        <version>1.4.3.RELEASE</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
[Spring Boot 1.4.3](https://github.com/spring-projects/spring-boot/releases/tag/v1.4.3.RELEASE) has just been released, and as far as I can tell it's a non-breaking change.  `mvn clean package`, `mvn test` and `mvn spring-boot:run` all run as expected.